### PR TITLE
Add stylelint as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,5 +2,8 @@
   "name": "stylelint-config-zendesk",
   "version": "1.0.2",
   "private": true,
-  "main": "index.js"
+  "main": "index.js",
+  "peerDependencies": {
+    "stylelint": ">=3.0.0"
+  }
 }


### PR DESCRIPTION
Ran into issues downstream complaining of breaking changes with stylelint >= 3.0.0 (namely https://github.com/stylelint/stylelint/commit/230b1ccf9b3b2c34d168ff838be40f945f183ba4).

Adding stylelint as a peer dependency will at least expose which versions of stylelint are compatible with the current release of stylelint-config.

/cc @jzempel 
