### PR TITLE
fix: disable `selector-max-pseudo-class` rule

### DIFF
--- a/rules/limit-language-features/selector.js
+++ b/rules/limit-language-features/selector.js
@@ -32,7 +32,7 @@ module.exports = {
     // Limit the number of id selectors in a selector
     'selector-max-id': 0,
     // Limit the number of pseudo-classes in a selector
-    'selector-max-pseudo-class': 0,
+    'selector-max-pseudo-class': null,
     // Limit the specificity of selectors
     'selector-max-specificity': '0,3,1',
     // Limit the number of type in a selector


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Original intent was to include this rule disabled, not to prevent all usage of pseudo classes!
