### PR TITLE
fix: update peerDependencies with stylelint 9.6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "yarn lint && yarn format && git diff --quiet"
   },
   "peerDependencies": {
-    "stylelint": "^9.4.x",
+    "stylelint": "^9.6.x",
     "stylelint-order": "^1.x"
   },
   "devDependencies": {

--- a/rules/stylistic-issues/general.js
+++ b/rules/stylistic-issues/general.js
@@ -17,6 +17,8 @@ module.exports = {
     'max-line-length': [80, {
       ignorePattern: ['/--zd-.+/']
     }],
+    // Disallow empty first lines
+    'no-empty-first-line': true,
     // Disallow end-of-line whitespace
     'no-eol-whitespace': true,
     // Disallow missing end-of-source newline


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Need to make sure `devDependencies` and `peerDependencies` stay in-sync. Add definition for new `no-empty-first-line` rule introduced in v9.6.0.
