### PR TITLE
fix: prevent husky from running on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
   ],
   "scripts": {
     "format": "prettier-package-json --write",
-    "postinstall": "husky install",
     "lint": "yarn lint:css && yarn lint:js",
     "lint:css": "echo 'a { all: unset; }' | stylelint --config index.js",
     "lint:js": "eslint index.js plugins/*.js rules/**/*.js",
+    "prepare": "husky install",
     "tag": "[ `git rev-parse --abbrev-ref HEAD` = 'main' ] && standard-version --no-verify",
     "test": "yarn lint && yarn format && git diff --quiet"
   },


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Prevent script error when `@zendeskgarden/stylelint-config` is installed as a dependency. Switch to `prepare` which is not run during package install.
