### PR TITLE
feat(stylelint)!: add declaration-property-max-values and selector-not-notation rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "yarn lint && yarn format && git diff --quiet"
   },
   "peerDependencies": {
-    "stylelint": "^14.0.0",
+    "stylelint": "^14.7.1",
     "stylelint-order": "^5.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "yarn lint && yarn format && git diff --quiet"
   },
   "peerDependencies": {
-    "stylelint": "^14.7.1",
+    "stylelint": "^14.7.0",
     "stylelint-order": "^5.0.0"
   },
   "devDependencies": {

--- a/rules/limit-language-features/declaration.js
+++ b/rules/limit-language-features/declaration.js
@@ -7,6 +7,8 @@
 
 module.exports = {
   rules: {
+    // Limit the number of values for a list of properties within declarations
+    'declaration-property-max-values': null,
     // Disallow `!important` within declarations
     'declaration-no-important': true,
     // Specify a list of disallowed property and unit pairs within declarations

--- a/rules/limit-language-features/selector.js
+++ b/rules/limit-language-features/selector.js
@@ -47,6 +47,8 @@ module.exports = {
     'selector-no-qualifying-type': [true, { ignore: 'class' }],
     // Disallow vendor prefixes for selectors
     'selector-no-vendor-prefix': true,
+    // Specify simple or complex notation for :not() pseudo-classes (Autofixable)
+    'selector-not-notation': true,
     // Specify a list of disallowed pseudo-class selectors
     'selector-pseudo-class-disallowed-list': null,
     // Specify a list of allowed pseudo-class selectors

--- a/rules/limit-language-features/selector.js
+++ b/rules/limit-language-features/selector.js
@@ -48,7 +48,7 @@ module.exports = {
     // Disallow vendor prefixes for selectors
     'selector-no-vendor-prefix': true,
     // Specify simple or complex notation for :not() pseudo-classes (Autofixable)
-    'selector-not-notation': true,
+    'selector-not-notation': ['simple'],
     // Specify a list of disallowed pseudo-class selectors
     'selector-pseudo-class-disallowed-list': null,
     // Specify a list of allowed pseudo-class selectors


### PR DESCRIPTION
## Description

Adding new rule definitions added since `v14.5.3` - `v14.7.1`.

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

## Detail

Adding [`declaration-property-max-values`](https://github.com/stylelint/stylelint/blob/main/lib/rules/declaration-property-max-values/README.md) & [`selector-not-notation`](https://github.com/stylelint/stylelint/blob/main/lib/rules/selector-not-notation/README.md) to the rules.


<!-- supporting details; code, etc. -->

<!-- closes GITHUB_ISSUE -->
