### PR TITLE
chore: add AI-ready documentation files

### DIFF
--- a/.cursor/rules/00-core.mdc
+++ b/.cursor/rules/00-core.mdc
@@ -1,0 +1,9 @@
+---
+description: Core project conventions
+globs: ["**/*"]
+alwaysApply: true
+---
+
+Read and follow all instructions in the root `AGENTS.md` file.
+Read and follow all security requirements in `SECURITY.md`.
+See `ARCHITECTURE.md` for system architecture and design decisions.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,5 @@
+# Copilot Instructions
+
+Read and follow all instructions in `AGENTS.md` — the source of truth for coding conventions.
+Read and follow all instructions in `SECURITY.md` — mandatory security requirements.
+See `ARCHITECTURE.md` for system architecture and design decisions.

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,0 +1,3 @@
+Read and follow all instructions in `AGENTS.md` — the source of truth for coding conventions.
+Read and follow all instructions in `SECURITY.md` — mandatory security requirements.
+See `ARCHITECTURE.md` for system architecture and design decisions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,131 @@
+# Garden stylelint Config
+
+## Project Overview
+
+`@zendeskgarden/stylelint-config` is a shareable [stylelint](https://stylelint.io/) configuration for Zendesk Garden design-system projects. It exports a single config object (`index.js`) that extends a set of focused rule files covering error-avoidance and convention-enforcement, plus a concentric property-ordering plugin.
+
+## Setup & Commands
+
+```bash
+# Install dependencies
+npm install
+
+# Run all checks (lint CSS + lint JS + verify formatting)
+npm test
+
+# Lint only
+npm run lint          # CSS self-test + JS linting
+npm run lint:css      # Validates config syntax by running stylelint against itself
+npm run lint:js       # ESLint with zero warnings allowed
+
+# Format package.json
+npm run format
+
+# Create a release tag (main branch only)
+npm run tag
+```
+
+## Repository Structure
+
+```
+stylelint-config/
+├── index.js                         # Entry point — extends all rule files
+├── rules/
+│   ├── avoid-errors/                # Rules that prevent CSS mistakes
+│   │   ├── deprecated.js            # Disallow deprecated at-rules/properties/etc.
+│   │   ├── descending.js            # Disallow descending specificity
+│   │   ├── duplicate.js             # Disallow duplicate selectors/properties
+│   │   ├── empty.js                 # Disallow empty blocks/sources
+│   │   ├── invalid.js               # Disallow invalid CSS constructs
+│   │   ├── irregular.js             # Disallow irregular whitespace
+│   │   ├── missing.js               # Require generic font families, etc.
+│   │   ├── non-standard.js          # Disallow non-standard direction/syntax
+│   │   ├── overrides.js             # Disallow overriding shorthand properties
+│   │   ├── unknown.js               # Disallow unknown rules/properties/values
+│   │   └── unmatchable.js           # Disallow unmatchable selectors
+│   └── enforce-conventions/         # Rules that enforce CSS coding style
+│       ├── allowed-disallowed-required.js  # Vendor prefix bans, named-color ban, etc.
+│       ├── case.js                  # Lowercase for functions/types/keywords
+│       ├── empty-lines.js           # Empty-line rules before at-rules/rules
+│       ├── max-min.js               # Max specificity, nesting depth limits
+│       ├── notation.js              # Color notation, font-weight numeric, hex short
+│       ├── pattern.js               # Naming patterns (zd-.+ for custom props/media/keyframes)
+│       ├── quotes.js                # Quote rules for fonts, urls, attributes
+│       ├── redundant.js             # Disallow longhand/redundant values
+│       └── whitespace-inside.js     # Whitespace inside comment markers
+└── plugins/
+    └── stylelint-order.js           # Concentric property-sort order
+```
+
+## Code Conventions
+
+- **Each rule file exports a single `module.exports = { rules: { ... } }` object** — no default exports, no named exports
+- Copyright header (Apache-2.0) is required at the top of every JS file
+- Inline comments above each rule explain its purpose (see existing files for the pattern)
+- Rule files must be registered in `index.js` under the `extends` array
+- New rule categories go in `rules/avoid-errors/` or `rules/enforce-conventions/`; a new top-level category would require a new subdirectory plus a matching entry in `index.js`
+- ESLint config (`eslint.config.mjs`) uses `@zendeskgarden/eslint-config` + prettier; match that style
+
+## Key Rules to Know
+
+- **`reportNeedlessDisables: true`** — needless `/* stylelint-disable */` comments are errors
+- **Custom naming pattern `zd-.+`** applies to: custom properties, custom media queries, and keyframe names
+- **No vendor prefixes** — at-rules, media features, properties, selectors, and values must all be unprefixed
+- **No `!important`** — `declaration-no-important: true`
+- **No named colors** — `color-named: 'never'`; use hex/rgb/hsl instead
+- **Property order** follows the concentric CSS model (layout → box model → typography); defined in `plugins/stylelint-order.js`
+- **Modern color notation**: short hex (`#fff` not `#ffffff`), numeric font-weight, `color()` modern syntax
+
+## Do
+
+- Keep each rule file focused on one logical category — match the existing naming/grouping
+- Add a short inline comment above every new rule explaining what it does
+- Run `npm test` before opening a PR; it catches lint violations and formatting drift
+- When adding a new rule file, add it to the `extends` array in `index.js`
+- Follow conventional commits format for PR titles (`feat:`, `fix:`, `chore:`, etc.)
+- Use `null` to intentionally leave a rule unconfigured (documents that it was considered)
+
+## Don't
+
+- Don't duplicate rules across multiple files — each rule lives in exactly one file
+- Don't add vendor-prefixed rules; the config explicitly bans vendor prefixes
+- Don't enable rules that conflict with the `reportNeedlessDisables: true` global setting
+- Don't change `index.js` structure without understanding that consumers extend the whole config
+- Don't modify `package.json` manually — use `npm run format` to keep it formatted
+
+## Architecture
+
+See `ARCHITECTURE.md` for component map and design decisions.
+
+## Security
+
+See `SECURITY.md` for mandatory security requirements.
+
+## Safety & Permissions
+
+Allowed without approval:
+- Read/list files
+- Run `npm test`, `npm run lint`, `npm run lint:css`, `npm run lint:js`
+
+Ask before:
+- Installing or removing packages
+- Running `npm run tag` (creates a release)
+- Pushing to remote branches
+- Modifying `package.json` dependencies
+
+## PR & Commit Guidelines
+
+- PR title must follow [Conventional Commits](https://conventionalcommits.org/): `type(scope): description` or `type: description`
+- Types: `feat`, `fix`, `chore`, `breaking`
+- Breaking changes: add `BREAKING CHANGE?` checkbox to PR description
+- Branch naming: `username/verb-noun`
+- Every PR must pass CI and receive at least one approval
+- See `.github/CONTRIBUTING.md` for full workflow
+
+## References
+
+- Architecture: `ARCHITECTURE.md`
+- Security: `SECURITY.md`
+- Contributing: `.github/CONTRIBUTING.md`
+- stylelint rules reference: https://stylelint.io/user-guide/rules
+- Concentric CSS order: https://github.com/brigade/scss-lint/blob/master/data/property-sort-orders/concentric.txt

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,103 @@
+# Garden stylelint Config — Architecture
+
+## System Overview
+
+`@zendeskgarden/stylelint-config` is a **shareable stylelint configuration package** published to npm as `@zendeskgarden/stylelint-config`. Consumers install it and point their `.stylelintrc` at it via the `extends` property. The package itself has no build step — it is pure JavaScript configuration objects consumed directly by stylelint at lint time.
+
+## Architecture Diagram
+
+```mermaid
+graph TD
+    Consumer["Consumer project\n(.stylelintrc: extends @zendeskgarden/stylelint-config)"]
+    Consumer --> Entry["index.js\n(extends all rule files)"]
+    Entry --> AvoidErrors["rules/avoid-errors/\n(11 rule files)"]
+    Entry --> EnforceConventions["rules/enforce-conventions/\n(9 rule files)"]
+    Entry --> Plugins["plugins/stylelint-order.js\n(concentric property order)"]
+    AvoidErrors --> Stylelint["stylelint\n(peer dependency)"]
+    EnforceConventions --> Stylelint
+    Plugins --> StylelintOrder["stylelint-order\n(dependency)"]
+    StylelintOrder --> Stylelint
+```
+
+## Component Map
+
+| Path | Responsibility |
+|------|----------------|
+| `index.js` | Single entry point; extends all rule files and sets `reportNeedlessDisables: true` |
+| `rules/avoid-errors/` | Rules that prevent invalid or erroneous CSS (unknown, deprecated, duplicate, invalid, etc.) |
+| `rules/enforce-conventions/` | Rules that enforce Garden's CSS style conventions (naming, notation, ordering hints, quoting) |
+| `plugins/stylelint-order.js` | Concentric property-sort-order plugin config |
+
+### Rule File Groupings
+
+**`rules/avoid-errors/`** (11 files — one concern per file):
+
+| File | Concern |
+|------|---------|
+| `deprecated.js` | Deprecated at-rules, properties, media types, keyword values |
+| `descending.js` | Descending specificity |
+| `duplicate.js` | Duplicate selectors, properties, font names, imports |
+| `empty.js` | Empty blocks, source, keyframes |
+| `invalid.js` | Invalid position declarations, at-rule preludes, syntax strings, missing scoping roots |
+| `irregular.js` | Irregular whitespace |
+| `missing.js` | Missing generic font families, required grid areas |
+| `non-standard.js` | Non-standard direction values, box-sizing |
+| `overrides.js` | Properties overridden by shorthand on the same line |
+| `unknown.js` | Unknown rules, properties, values, functions, units, pseudo-classes/elements |
+| `unmatchable.js` | Unmatchable `@keyframes` selectors, `::after` pseudo-element selectors |
+
+**`rules/enforce-conventions/`** (9 files):
+
+| File | Concern |
+|------|---------|
+| `allowed-disallowed-required.js` | Vendor prefix bans, named-color ban, `!important` ban, url scheme allowlist |
+| `case.js` | Lowercase for function names, type selectors, keyword values |
+| `empty-lines.js` | Required empty lines before `@rules` and rules |
+| `max-min.js` | Maximum specificity / nesting depth limits |
+| `notation.js` | Short hex, numeric font-weight, modern color functions, `string` import notation |
+| `pattern.js` | Naming: `zd-.+` for custom properties, custom media, and keyframe names |
+| `quotes.js` | Quote conventions for font families, urls, attribute values |
+| `redundant.js` | Redundant longhand / shorthand values |
+| `whitespace-inside.js` | Whitespace inside comment markers |
+
+## Key Design Decisions
+
+### Single Entry Point with Composable Rule Files
+`index.js` uses stylelint's `extends` array to compose focused rule files rather than putting all rules in one file. This makes the config easy to audit by concern — each file is a single logical category.
+
+### One Rule Per File Principle
+Each file addresses exactly one concern (e.g., `duplicate.js` handles all duplicate-related rules). This makes changes easy to review and keeps diffs minimal when rules are updated.
+
+### Intentional `null` Values
+Rule entries set to `null` are explicitly unconfigured rather than absent — this documents that the rule was considered and intentionally left to consumers to configure if needed.
+
+### `reportNeedlessDisables: true`
+Enabled globally in `index.js` so that stale `/* stylelint-disable */` comments in consumer code are surfaced as errors, preventing suppress-and-forget patterns.
+
+### No Build Step
+The package ships raw JS `module.exports` objects. There is no transpilation, no bundling — what's in the repo is exactly what's published to npm.
+
+### Naming Conventions Enforced (`zd-.+`)
+Custom properties, custom media queries, and keyframe animation names must match `zd-.+`. This namespaces Garden's tokens and prevents accidental clashes with consumer code.
+
+## External Dependencies
+
+| Dependency | Type | Purpose |
+|------------|------|---------|
+| `stylelint` | peer | Core linter that reads this config |
+| `stylelint-order` | production | Enables `order/properties-order` for concentric CSS sorting |
+| `@zendeskgarden/eslint-config` | dev | ESLint config used to lint this repo's own JS files |
+| `prettier-package-json` | dev | Formats `package.json` |
+| `commit-and-tag-version` | dev | Generates CHANGELOG and tags releases |
+| `husky` | dev | Runs lint + format as a pre-commit hook |
+
+## Cross-Cutting Concerns
+
+### Versioning
+Follows semantic versioning. Major versions are cut when rules are added or changed in ways that would fail previously-passing CSS. Use `npm run tag` on `main` to cut a release.
+
+### CI / Pre-commit
+The pre-commit hook (via husky) runs `npm run lint && npm run format`. The `npm test` script adds a `git diff --quiet` check to ensure formatting is committed.
+
+### Publishing
+Publishes to npm under `@zendeskgarden` scope with `"access": "public"`. Only `plugins/` and `rules/` are included in the published package (plus `index.js` as `main`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Claude Code Configuration
+
+Read and follow all instructions in `AGENTS.md` — the source of truth for coding conventions.
+Read and follow all instructions in `SECURITY.md` — mandatory security requirements.
+See `ARCHITECTURE.md` for system architecture and design decisions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,98 @@
+# AI Agent Security Standard
+
+This document defines mandatory security principles and restrictions for all AI coding assistants operating in this repository. All AI agents must follow these requirements without exception.
+
+**Authority:** Derived from [Zendesk Minimum Baseline Security Standard](https://docs.google.com/document/d/17GZ9TpjKCt6WCdw3yxL44Ra_YscbOBVnVkUVGgx5Hz0/) and internal security policies.
+
+---
+
+## Core Security Mandate
+
+Security is a first-class requirement. Every code suggestion must be evaluated against these guidelines. If a request would result in insecure code:
+
+1. **Stop** and flag the security concern
+2. **Explain** why it's problematic
+3. **Propose** a secure alternative
+
+AI-generated code requires human review before merging.
+
+---
+
+## Absolute Prohibitions
+
+AI agents must **NEVER** do the following:
+
+### Secrets & Credentials
+- Hardcode secrets, credentials, API keys, tokens, or passwords in source code
+- Store secrets in version control (`.env` files, config with real values)
+- Log, print, or expose secret values
+- Expose credentials in URLs, logs, or error messages
+
+### Security Controls
+- Disable or weaken security controls (`verify=False`, `ALLOW_ALL` CORS, disabled auth)
+- Bypass authentication or authorization checks
+- Disable certificate validation
+
+### Dangerous Code Patterns
+- Execute shell commands using raw string interpolation from user input
+- Use `eval()` or `exec()` with user-supplied input
+- Implement custom cryptography
+- Use deprecated algorithms (MD5, SHA-1, DES, RC4, ECB mode)
+
+### Data Exposure
+- Log sensitive data (PII, credentials, tokens)
+- Expose stack traces or internal paths to end users
+- Transmit sensitive data over unencrypted channels
+
+---
+
+## Repository-Specific Security Notes
+
+This is a **CSS linting configuration package** with no runtime execution, no authentication, no database access, and no user data handling. The primary security considerations are:
+
+### Dependency Security
+- Do not add new runtime `dependencies` without security review — the published package is consumed by many downstream projects
+- Prefer well-maintained, widely-used packages; avoid packages with known vulnerabilities
+- Dependabot and Renovate are configured to keep dependencies current — do not disable them
+
+### Supply Chain Integrity
+- Do not modify `package.json` `dependencies` or `devDependencies` directly — propose changes and let maintainers review
+- The `publishConfig.access: "public"` setting means changes ship directly to public npm; take extra care with published files (`plugins/`, `rules/`)
+- Only files listed in the `files` field of `package.json` are published; do not add sensitive files there
+
+### Published File Safety
+- Do not add API keys, tokens, internal URLs, or internal system names to any file under `rules/` or `plugins/` — these are shipped to npm and are public
+- The copyright header in every JS file is required — do not remove it
+
+---
+
+## When to Stop and Escalate
+
+Stop, explain the concern, and recommend involving Security if a task requires:
+
+- Adding a new runtime dependency from an unfamiliar or unvetted source
+- Modifying the `files` field in `package.json` in a way that could expose sensitive files
+- Disabling Dependabot or Renovate security updates
+- Any change that could introduce executable code that runs in consumer projects at lint time
+
+---
+
+## Security Testing
+
+When generating features or changes, include:
+
+- Verification that no secrets or internal paths appear in files under `rules/` or `plugins/`
+- Checks that new dependencies have recent publish dates and active maintenance
+- Review that the `files` field in `package.json` only includes intended public files
+
+---
+
+## References
+
+- [Minimum Baseline Security Standard](https://docs.google.com/document/d/17GZ9TpjKCt6WCdw3yxL44Ra_YscbOBVnVkUVGgx5Hz0/)
+- [Cryptography Standards](https://techmenu.zende.sk/standards/cryptography-standards/)
+- [Zendesk Security Engagement](https://techmenu.zende.sk/security/)
+
+---
+
+**Questions?** Reach out to the Security team or file a ticket via the Security Engagement process.


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- No -->

## Description

Add AI-ready documentation to make the repository usable by AI coding assistants (Claude Code, GitHub Copilot, Cursor, Windsurf, and others).

Files added:
- **`AGENTS.md`** — vendor-neutral conventions hub: project overview, commands, repo structure, rule conventions, do/don't lists, PR guidelines
- **`ARCHITECTURE.md`** — system architecture, component map, design decisions, dependency table
- **`SECURITY.md`** — AI agent security constraints, supply-chain safety notes, escalation triggers
- **`CLAUDE.md`** — thin spoke for Claude Code, references AGENTS.md and SECURITY.md
- **`.github/copilot-instructions.md`** — thin spoke for GitHub Copilot
- **`.cursor/rules/00-core.mdc`** — thin spoke for Cursor with MDC frontmatter
- **`.windsurfrules`** — thin spoke for Windsurf

## Detail

All files follow the hub-and-spoke model: AGENTS.md and SECURITY.md are the single sources of truth; tool-specific files are thin references to both. No source code was modified.

---
Requested by @sanjay-zendesk via [zendesk/ai-repo#323](https://github.com/zendesk/ai-repo/issues/323)